### PR TITLE
Update input's `batch_id` in `CollectOutputContext`

### DIFF
--- a/src/render/prepare/instance_buffer_updater.rs
+++ b/src/render/prepare/instance_buffer_updater.rs
@@ -1,3 +1,4 @@
+use crate::allocator::id_allocator::IdAllocator;
 use crate::allocator::utils::ensure_buffer_capacity;
 use crate::render::prepare::{core::Clear, utils::data_offset, *};
 
@@ -39,7 +40,11 @@ impl<'a> InstanceBufferUpdater<'a> {
             source_buffer,
             inputs,
         });
-        self.collect_output_writes(CollectOutputContext { entities, inputs })
+        self.collect_output_writes(CollectOutputContext {
+            entities,
+            inputs,
+            source_id_allocator: &page.id_allocator,
+        })
     }
 
     fn ensure_capacity(&self, page: &mut InstancePage, capacity: u64) {
@@ -126,14 +131,18 @@ impl<'a> InstanceBufferUpdater<'a> {
             .filter_map(|e| ctx.inputs.get(e))
             .filter(|i| !i.gpu_cull)
             .filter_map(|input| {
-                self.source_allocator
-                    .get(input.entity)
-                    .map(|alloc| (input, alloc))
+                let alloc = self.source_allocator.get(input.entity)?;
+                let batch_id = *ctx.source_id_allocator.allocations.get(&input.entity)?;
+                Some((input, alloc, batch_id))
             })
-            .map(|(input, alloc)| {
+            .map(|(input, alloc, batch_id)| {
                 (
                     alloc.offset as u64 * size_of::<InstanceData>() as u64,
-                    input.instances.to_vec(),
+                    input
+                        .instances
+                        .iter()
+                        .map(|d| d.with_batch_id(batch_id))
+                        .collect::<Vec<_>>(),
                 )
             })
             .collect()
@@ -149,4 +158,5 @@ struct ProcessWriteContext<'a> {
 struct CollectOutputContext<'a> {
     entities: &'a Vec<Entity>,
     inputs: &'a EntityHashMap<BatchInput>,
+    source_id_allocator: &'a IdAllocator,
 }


### PR DESCRIPTION
I just noticed that in sister repository `bevy_feronia` a few examples have broken LODs on dev branch: `scatter_instanced_grass`, `scatter_instanced_density_map` (and maybe other). But `scatter_instanced_chunks` was working fine.

From what I could gather, chunks were working fine, because they were gpu culled, and that is obviously skips the whole output collection. But for cases without gpu cull we do need correct `batch_id`: and it was never properly updated (?). To be honest, I can barely able to understand what's going on here, so I'm not sure how destructive this PR is, but all of those 3 examples do work as expected now.